### PR TITLE
Correct 'user guide' and 'design document' Markdown links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ There are a few open-source projects that can convert Java objects to JSON. Howe
 
 *Gson Documentation*
   * Gson [API](http://google-gson.googlecode.com/svn/trunk/gson/docs/javadocs/index.html): Javadocs for the current Gson release
-  * Gson [user guide](http://sites.google.com/site/gson/gson-user-guide user guide): This guide contains examples on how to use Gson in your code.
+  * Gson [user guide](http://sites.google.com/site/gson/gson-user-guide): This guide contains examples on how to use Gson in your code.
   * Gson [Roadmap](https://sites.google.com/site/gson/gson-roadmap): Details on upcoming releases 
-  * Gson [design document](https://sites.google.com/site/gson/gson-design-document design document): This document discusses issues we faced while designing Gson. It also include a comparison of Gson with other Java libraries that can be used for Json conversion
+  * Gson [design document](https://sites.google.com/site/gson/gson-design-document): This document discusses issues we faced while designing Gson. It also include a comparison of Gson with other Java libraries that can be used for Json conversion
 
 Please use the [google-gson Google group](http://groups.google.com/group/google-gson) to discuss Gson, or to post questions. 
 


### PR DESCRIPTION
Closes #633. 